### PR TITLE
Remove PHP Logic from metadata.php

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -10,21 +10,14 @@
      */
     $sMetadataVersion = '2.0';
 
-    $troCurrentLanguageAbbreviation = OxidEsales\Eshop\Core\Registry::getLang()->translateString('TRO_CURRENT_LANGUAGE');
-
-    if (empty($troCurrentLanguageAbbreviation))
-    {
-        $troCurrentLanguageAbbreviation = 'en';
-    }
-
     $aModule = [
         'id'          => 'trosofortueberweisung',
-        'title'       => '<img height="10px" style="margin-top: 3px;" src="../modules/tronet/trosofortueberweisung/out/img/tronet.gif" /> Sofort.',
+        'title'       => 'Sofort.',
         'description' => [
             'de' => 'Sofort. by tronet',
             'en' => 'Sofort. by tronet',
         ],
-        'thumbnail'   => "out/img/logo_sofort.php?language=be_{$troCurrentLanguageAbbreviation}&columns=250&rows=55",
+        'thumbnail'   => "out/img/logo_sofort_fallback.png",
         'version'     => '8.0.8',
         'author'      => 'tronet GmbH',
         'email'       => 'integration@sofort.com',


### PR DESCRIPTION
Remove PHP Logic from metadata.php, not allowed since OXID eShop Serie 6.2 and greater